### PR TITLE
Update Deliveroo selectors for new API

### DIFF
--- a/src/server/gamble/deliveroo/deliveroo-state-selector/getMenuItemsFromDeliverooState.ts
+++ b/src/server/gamble/deliveroo/deliveroo-state-selector/getMenuItemsFromDeliverooState.ts
@@ -4,7 +4,8 @@ import { DeliverooState } from "../../../type/deliveroo/DeliverooState";
 const getMenuItemsFromDeliverooState = (
     state: DeliverooState
 ): DeliverooItem[] => {
-    const items = state?.props?.initialState?.menuPage?.menu?.meta?.items;
+    const items =
+        state?.props?.initialState?.menuPage?.menu?.metas?.root?.items;
 
     if (!items) {
         console.log("No items in state");

--- a/src/server/gamble/deliveroo/deliveroo-state-selector/getModifierGroupsFromDeliverooState.ts
+++ b/src/server/gamble/deliveroo/deliveroo-state-selector/getModifierGroupsFromDeliverooState.ts
@@ -4,7 +4,9 @@ import { DeliverooModifierGroup } from "../../../type/deliveroo/DeliverooModifie
 const getModifierGroupsFromDeliverooState = (
     state: DeliverooState
 ): DeliverooModifierGroup[] => {
-    return state.props.initialState.menuPage.menu.meta.modifierGroups;
+    return (
+        state.props.initialState.menuPage.menu.metas.root.modifierGroups
+    );
 };
 
 export { getModifierGroupsFromDeliverooState };

--- a/src/server/gamble/deliveroo/deliveroo-state-selector/getPlaceToEatMetaFromDeliverooState.ts
+++ b/src/server/gamble/deliveroo/deliveroo-state-selector/getPlaceToEatMetaFromDeliverooState.ts
@@ -6,7 +6,7 @@ import {
 const getPlaceToEatMetaFromDeliverooState = (
     state: DeliverooState
 ): DeliverooMenuMetaState => {
-    return state.props.initialState.menuPage.menu.meta;
+    return state.props.initialState.menuPage.menu.metas.root;
 };
 
 export { getPlaceToEatMetaFromDeliverooState };

--- a/src/server/type/deliveroo/DeliverooState.ts
+++ b/src/server/type/deliveroo/DeliverooState.ts
@@ -31,7 +31,9 @@ type DeliverooMenuMetaState = {
 
 type DeliverooMenuPageState = {
     menu: {
-        meta: DeliverooMenuMetaState;
+        metas: {
+            root: DeliverooMenuMetaState;
+        };
         layoutGroups: {
             layouts: UILayoutGrid[];
         }[];


### PR DESCRIPTION
## Summary
- adjust Deliveroo state interfaces for new `metas.root` structure
- update selectors to read items, modifier groups and meta from new location

## Testing
- `yarn test` *(fails: SearchPage.spec.tsx - localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_6883dfee30f8832eafd0e202d12f03e3