### PR TITLE
Replace node-fetch with built-in fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
         "express": "^4.17.3",
         "formik": "^2.2.9",
         "https-proxy-agent": "^7.0.4",
-        "node-fetch": "^3.2.3",
         "postcode": "^5.1.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",

--- a/src/server/gamble/deliveroo/get-restaurant-data/postcode/get-places-to-eat-url/getPlacesToEatUrl.ts
+++ b/src/server/gamble/deliveroo/get-restaurant-data/postcode/get-places-to-eat-url/getPlacesToEatUrl.ts
@@ -1,5 +1,4 @@
 import { geocode } from "./google-maps/geocode";
-import fetch, { RequestInit } from "node-fetch";
 import { Cuisine, CuisineUrlParam } from "../../../../../../common/type/Cuisine";
 import { getProxy } from "../../../../../util/proxy/proxy";
 

--- a/src/server/gamble/deliveroo/get-restaurant-data/postcode/get-places-to-eat-url/google-maps/geocode.ts
+++ b/src/server/gamble/deliveroo/get-restaurant-data/postcode/get-places-to-eat-url/google-maps/geocode.ts
@@ -1,4 +1,3 @@
-import fetch from "node-fetch";
 import * as dotenv from "dotenv";
 import { Cache } from "../../../../../../util/cache";
 

--- a/src/server/util/doDeliverooFetch.ts
+++ b/src/server/util/doDeliverooFetch.ts
@@ -1,4 +1,3 @@
-import fetch, { RequestInit, Response } from "node-fetch";
 import { parseCookie } from "./parseCookie";
 import { createCookie } from "./createCookie";
 import { getProxy } from "./proxy/proxy";

--- a/src/server/util/proxy/validateProxy.ts
+++ b/src/server/util/proxy/validateProxy.ts
@@ -1,5 +1,4 @@
 import { HttpsProxyAgent } from "https-proxy-agent";
-import fetch from "node-fetch";
 
 /**
  * Validate a proxy works, and throw if it does not.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5093,14 +5093,6 @@ node-domexception@^1.0.0:
   resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
   integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
 
-node-fetch@^3.2.3:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
-  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-forge@^1:
   version "1.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2841,11 +2841,6 @@ csstype@^3.0.2:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.1.3.tgz#d80ff294d114fb0e6ac500fbf85b60137d7eff81"
   integrity sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
-
 data-urls@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/data-urls/-/data-urls-2.0.0.tgz#156485a72963a970f5d5821aaf642bef2bf2db9b"
@@ -3427,14 +3422,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 fill-range@^7.1.1:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
@@ -3504,13 +3491,6 @@ form-data@^3.0.0:
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.2"
     mime-types "^2.1.35"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 formik@^2.2.9:
   version "2.4.6"
@@ -5087,12 +5067,6 @@ node-addon-api@^7.0.0:
   version "7.1.1"
   resolved "https://registry.yarnpkg.com/node-addon-api/-/node-addon-api-7.1.1.tgz#1aba6693b0f255258a049d621329329322aad558"
   integrity sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==
-
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
 
 node-forge@^1:
   version "1.3.1"
@@ -6877,11 +6851,6 @@ wbuf@^1.1.0, wbuf@^1.7.3:
   integrity sha512-O84QOnr0icsbFGLS0O3bI5FswxzRr8/gHwWkDlQFskhSPryQXvrTMxjxGP4+iWYoauLoBvfDpkrOauZ+0iZpDA==
   dependencies:
     minimalistic-assert "^1.0.0"
-
-web-streams-polyfill@^3.0.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
-  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webidl-conversions@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Summary
- remove `node-fetch` dependency
- use the global `fetch` provided by Node

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_688526c8bd00832e97e3aad60f8d4c4b